### PR TITLE
loom: fix swiftlint error with 0.24.0 version

### DIFF
--- a/Weavy/Loom.swift
+++ b/Weavy/Loom.swift
@@ -9,8 +9,6 @@
 import Foundation
 import RxSwift
 
-// swiftlint:disable class_delegate_protocol
-
 /// Delegate used to communicate from a WarpWeaver
 protocol WarpWeaverDelegate: class {
 
@@ -27,7 +25,6 @@ protocol WarpWeaverDelegate: class {
     func willKnit (withWarp warp: Warp, andWeft weft: Weft)
     func didKnit (withWarp warp: Warp, andWeft weft: Weft)
 }
-// swiftlint:enable class_delegate_protocol
 
 /// A WarpWeaver handles the weaving for a dedicated Warp
 /// It will listen for Wefts emitted be the Warp Weftable companion or


### PR DESCRIPTION
Before this commit, with a 0.24.0 SwiftLint version, there was a
"Superfluous Disable Command Violation" that prevented the project to
build.
The whole error is available in the linked issue: #8

This commit removes the SwiftLint instruction of this file, thus
allowing the project to build properly.