### PR TITLE
project: fix private_over_fileprivate warnings

### DIFF
--- a/Weavy/HasDisposeBag.swift
+++ b/Weavy/HasDisposeBag.swift
@@ -10,7 +10,7 @@ import Foundation
 import RxSwift
 import ObjectiveC
 
-fileprivate var disposeBagContext: UInt8 = 0
+private var disposeBagContext: UInt8 = 0
 
 /// Each HasDisposeBag offers a unique Rx DisposeBag instance
 public protocol HasDisposeBag: Synchronizable {

--- a/Weavy/Warp.swift
+++ b/Weavy/Warp.swift
@@ -10,7 +10,7 @@ import Foundation
 import RxSwift
 import UIKit
 
-fileprivate var subjectContext: UInt8 = 0
+private var subjectContext: UInt8 = 0
 
 /// A Warp defines a clear navigation area. Combined to a Weft it leads to a navigation action
 public protocol Warp: Presentable {

--- a/Weavy/Weftable.swift
+++ b/Weavy/Weftable.swift
@@ -9,7 +9,7 @@
 import Foundation
 import RxSwift
 
-fileprivate var subjectContext: UInt8 = 0
+private var subjectContext: UInt8 = 0
 
 /// a Weftable has only one purpose: emit Wefts that correspond to specific navigation states.
 /// The state changes lead to navigation actions in the context of a specific Warp


### PR DESCRIPTION
This commit removes the private_over_fileprivate wargings triggered by
SwiftLint. To do so, fileprivate access modifiers were replaced by
private when necessary.

"Private over fileprivate Violation: Prefer `private` over `fileprivate` declarations. (private_over_fileprivate)"