### PR TITLE
travis-ci: use swiftlint latest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 before_install:
   - brew update
   - brew outdated carthage || brew upgrade carthage
-  - brew install swiftlint || true
+  - brew outdated swiftlint || brew upgrade swiftlint
   - carthage bootstrap --verbose --platform iOS --cache-builds
 script:
     - xcodebuild clean test -project Weavy.xcodeproj -scheme Weavy -destination "platform=iOS Simulator,name=iPhone 8,OS=11.0" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO -quiet | xcpretty -c


### PR DESCRIPTION
This commit forces the CI to use the latest version of swiftlint to run
the static code analysis.
It will handle issues like #8, and solves the #11 one.